### PR TITLE
Add workflow for building images + uploading tarballs to github artifacts

### DIFF
--- a/.github/actions/load-docker-images-from-artifacts/action.yml
+++ b/.github/actions/load-docker-images-from-artifacts/action.yml
@@ -4,11 +4,20 @@ description: Load Docker Images from artifacts into k3d
 runs:
   using: "composite"
   steps:
+  - name: Make temp dir
+    id: artifact_temp_dir
+    shell: bash
+    run: |
+      path="/tmp/load-docker-images-from-artifacts"
+      mkdir -p "$path"
+      echo "path=${path}" >> $GITHUB_OUTPUT
+
   # should download emissary.tar, kat-client.tar, kat-server.tar
   - name: Download artifacts
     id: artifact_download
     uses: actions/download-artifact@v4
-
+    with:
+      path: ${{ steps.artifact_temp_dir.outputs.path }}
 
   - name: Import tarballs into k3d
     shell: bash
@@ -17,6 +26,5 @@ runs:
       for image in "${images[@]}"
       do
         echo "Importing ${image}.tar into k3d cluster"
-        ./tools/bin/k3d image import "${{steps.artifact_download.outputs.download-path}}/${image}.tar/${image}.tar"
-        rm -rf "${{steps.artifact_download.outputs.download-path}}/${image}.tar"
+        ./tools/bin/k3d image import "${{ steps.artifact_temp_dir.outputs.path }}/${image}.tar/${image}.tar"
       done

--- a/.github/actions/load-docker-images-from-artifacts/action.yml
+++ b/.github/actions/load-docker-images-from-artifacts/action.yml
@@ -26,12 +26,14 @@ runs:
       unzip ${{ steps.artifact_temp_dir.outputs.path }}/build-images-checksums-and-tags.zip/build-images-checksums-and-tags.zip -d ${{ github.workspace }}/docker
       ls -alh ${{ github.workspace }}/docker
 
-  - name: Import tarballs into k3d
+  - name: Import tarballs into k3d and docker
     shell: bash
     run: |
       images=("emissary" "kat-client" "kat-server" "test-auth" "test-shadow" "test-stats")
       for image in "${images[@]}"
       do
+        echo "Importing ${image}.tar into docker"
+        docker image load --input "${{ steps.artifact_temp_dir.outputs.path }}/${image}.tar/${image}.tar"
         echo "Importing ${image}.tar into k3d cluster"
         ./tools/bin/k3d image import "${{ steps.artifact_temp_dir.outputs.path }}/${image}.tar/${image}.tar"
       done

--- a/.github/actions/load-docker-images-from-artifacts/action.yml
+++ b/.github/actions/load-docker-images-from-artifacts/action.yml
@@ -19,6 +19,13 @@ runs:
     with:
       path: ${{ steps.artifact_temp_dir.outputs.path }}
 
+  - name: Extract checksum archive
+    shell: bash
+    run: |
+      set -eou pipefail
+      unzip ${{ steps.artifact_temp_dir.outputs.path }}/build-images-checksums-and-tags.zip/build-images-checksums-and-tags.zip -d ${{ github.workspace }}/docker
+      ls -alh ${{ github.workspace }}/docker
+
   - name: Import tarballs into k3d
     shell: bash
     run: |

--- a/.github/actions/load-docker-images-from-artifacts/action.yml
+++ b/.github/actions/load-docker-images-from-artifacts/action.yml
@@ -13,7 +13,7 @@ runs:
   - name: Import tarballs into k3d
     shell: bash
     run: |
-      images=("emissary" "kat-client" "kat-server")
+      images=("emissary" "kat-client" "kat-server" "test-auth" "test-shadow" "test-stats")
       for image in "${images[@]}"
       do
         echo "Importing ${image}.tar into k3d cluster"

--- a/.github/actions/load-docker-images-from-artifacts/action.yml
+++ b/.github/actions/load-docker-images-from-artifacts/action.yml
@@ -17,6 +17,6 @@ runs:
       for image in "${images[@]}"
       do
         echo "Importing ${image}.tar into k3d cluster"
-        ls -alh "${{steps.artifact_download.outputs.download-path}}/${image}.tar/"
         ./tools/bin/k3d image import "${{steps.artifact_download.outputs.download-path}}/${image}.tar/${image}.tar"
+        rm -rf "${{steps.artifact_download.outputs.download-path}}/${image}.tar"
       done

--- a/.github/actions/load-docker-images-from-artifacts/action.yml
+++ b/.github/actions/load-docker-images-from-artifacts/action.yml
@@ -1,0 +1,22 @@
+name: load-docker-images-from-artifacts
+description: Load Docker Images from artifacts into k3d
+
+runs:
+  using: "composite"
+  steps:
+  # should download emissary.tar, kat-client.tar, kat-server.tar
+  - name: Download artifacts
+    id: artifact_download
+    uses: actions/download-artifact@v4
+
+
+  - name: Import tarballs into k3d
+    shell: bash
+    run: |
+      images=("emissary" "kat-client" "kat-server")
+      for image in "${images[@]}"
+      do
+        echo "Importing ${image}.tar into k3d cluster"
+        ls -alh "${{steps.artifact_download.outputs.download-path}}/${image}.tar/"
+        ./tools/bin/k3d image import "${{steps.artifact_download.outputs.download-path}}/${image}.tar/${image}.tar"
+      done

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           set -eou pipefail
           make save-dev
+          make save-pytest-images
 
       - name: Upload emissary docker image tarball
         uses: actions/upload-artifact@v4
@@ -43,3 +44,20 @@ jobs:
           name: kat-server.tar
           path: kat-server.tar
 
+      - name: Upload test-auth docker image tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-auth.tar
+          path: test-auth.tar
+
+      - name: Upload test-shadow docker image tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-shadow.tar
+          path: test-shadow.tar
+
+      - name: Upload test-stats docker image tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-stats.tar
+          path: test-stats.tar

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,39 @@
+name: Build images
+
+on: [workflow_call, push]
+
+jobs:
+  build-images:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Deps
+        uses: ./.github/actions/setup-deps
+
+      - name: Build Docker Images and save tarballs
+        shell: bash
+        run: |
+          set -eou pipefail
+          make save-dev
+
+      - name: Upload emissary docker image tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: emissary.tar
+          path: emissary.tar
+
+      - name: Upload kat-client docker image tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: kat-client.tar
+          path: kat-client.tar
+
+      - name: Upload kat-server docker image tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: kat-server.tar
+          path: kat-server.tar
+

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -4,6 +4,7 @@ on: [workflow_call, push]
 
 env:
   VERSION: v0.0.0-build-images
+  CHART_VERSION: v0.0.0-build-images
 
 jobs:
   build-images:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -61,3 +61,23 @@ jobs:
         with:
           name: test-stats.tar
           path: test-stats.tar
+
+      - name: Save image checksums/tags
+        id: image-checksum
+        shell: bash
+        run: |
+          mkdir -p /tmp/image-checksums-and-tags
+          images=("emissary" "kat-client" "kat-server" "test-auth" "test-shadow" "test-stats")
+          for image in "${images[@]}"
+          do
+            cp "docker/${image}.docker" "/tmp/image-checksums-and-tags/${image}.docker"
+            cp "docker/${image}.docker.tag.local" "/tmp/image-checksums-and-tags/${image}.docker.tag.local"
+          done
+          (cd /tmp/image-checksums-and-tags && zip build-images-checksums-and-tags.zip *.docker *.docker.tag.local)
+          echo "archive_path=/tmp/image-checksums-and-tags/build-images-checksums-and-tags.zip" >> $GITHUB_OUTPUT
+
+      - name: Upload archive containing image checksums and tags
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-images-checksums-and-tags.zip
+          path: ${{ steps.image-checksum.outputs.archive_path }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -2,6 +2,9 @@ name: Build images
 
 on: [workflow_call, push]
 
+env:
+  VERSION: v0.0.0-build-images
+
 jobs:
   build-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Build Docker Images and save tarballs
         shell: bash
+        env:
+          SKIP_PUSH: "true"
         run: |
           set -eou pipefail
           make save-dev

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,6 +1,6 @@
 name: Build images
 
-on: [workflow_call, push]
+on: [workflow_call]
 
 env:
   VERSION: v0.0.0-build-images

--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -1,12 +1,7 @@
 name: job-promote-to-passed
 
 "on":
-  push:
-    branches:
-      - master
-      - release/v*
-  pull_request: {}
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   lint: ########################################################################
@@ -230,6 +225,8 @@ jobs:
           sudo sysctl -w fs.inotify.max_user_instances=4096
 
           make ci/setup-k3d
+      - name: Load Docker Images into k3d cluster # has to be done after k3d is installed
+        uses: ./.github/actions/load-docker-images-from-artifacts
       - name: Setup integration test environment
         run: |
           export DEV_KUBE_NO_PVC=yes

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -1,10 +1,8 @@
 name: k8s-e2e
 
 "on":
-  pull_request: {}
-  schedule:
-    - cron: "0 7 * * *" # at 7am UTC everyday
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   acceptance_tests:
@@ -39,12 +37,6 @@ jobs:
           fetch-depth: 0
       - name: Install Deps
         uses: ./.github/actions/setup-deps
-      - name: "Docker Login"
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ (!startsWith(secrets.DEV_REGISTRY, 'docker.io/')) && secrets.DEV_REGISTRY || null }}
-          username: ${{ secrets.GH_DOCKER_BUILD_USERNAME }}
-          password: ${{ secrets.GH_DOCKER_BUILD_TOKEN }}
       - name: Create integration test cluster
         env:
           K3S_VERSION: ${{matrix.k8s.k3s}}
@@ -54,6 +46,8 @@ jobs:
           sudo sysctl -w fs.inotify.max_user_instances=4096
 
           make ci/setup-k3d
+      - name: Load Docker Images into k3d cluster # has to be done after k3d is installed
+        uses: ./.github/actions/load-docker-images-from-artifacts
       - name: Setup integration test environment
         run: |
           export DEV_KUBE_NO_PVC=yes

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -56,6 +56,7 @@ jobs:
           export KAT_REQ_LIMIT=900
           export DEV_KUBECONFIG=~/.kube/config
           export DEV_REGISTRY=${{ secrets.DEV_REGISTRY }}
+          export SKIP_PUSH="true"
           make python-integration-test-environment
       - name: Run ${{ matrix.test }}
         run: |

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -14,6 +14,8 @@ jobs:
       DEV_USE_IMAGEPULLSECRET: ${{ secrets.DEV_USE_IMAGEPULLSECRET }}
       DOCKER_BUILD_USERNAME: ${{ secrets.GH_DOCKER_BUILD_USERNAME }}
       DOCKER_BUILD_PASSWORD: ${{ secrets.GH_DOCKER_BUILD_TOKEN }}
+      VERSION: v0.0.0-build-images
+      CHART_VERSION: v0.0.0-build-images
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,10 +11,10 @@ jobs:
     uses: ./.github/workflows/build-images.yml
     secrets: inherit
 
-  execute-tests-and-promote:
-    needs: [build-images]
-    uses: ./.github/workflows/execute-tests-and-promote.yml
-    secrets: inherit
+  # execute-tests-and-promote:
+  #   needs: [build-images]
+  #   uses: ./.github/workflows/execute-tests-and-promote.yml
+  #   secrets: inherit
 
   k8s-e2e:
     needs: [build-images]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,22 @@
+name: Run tests
+
+on:
+  # pull request: {}
+  workflow_dispatch:
+  schedule:
+    - cron: "0 7 * * *" # at 7am UTC everyday
+
+jobs:
+  build-images:
+    uses: ./.github/workflows/build-images.yml
+    secrets: inherit
+
+  execute-tests-and-promote:
+    needs: [build-images]
+    uses: ./.github/workflows/execute-tests-and-promote.yml
+    secrets: inherit
+
+  k8s-e2e:
+    needs: [build-images]
+    uses: ./.github/workflows/k8s-e2e.yml
+    secrets: inherit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,7 @@
 name: Run tests
 
 on:
-  # pull request: {}
+  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "0 7 * * *" # at 7am UTC everyday

--- a/build-aux/builder.mk
+++ b/build-aux/builder.mk
@@ -443,6 +443,14 @@ save-dev: FORCE inspect-image-cache images-build
 	done
 .PHONY: save-dev
 
+_save-pytest-images = test-auth test-shadow test-stats
+save-pytest-images: FORCE inspect-image-cache build-pytest-images
+	@for image in $(_save-pytest-images); do \
+		printf '$(CYN)==> $(GRN)saving image %s as tarball: $(BLU)%s.tar$(GRN)...$(END)\n' $$image $$image; \
+		docker image save --output $$image.tar $$(cat docker/$$image.docker); \
+	done
+.PHONY: save-pytest-images
+
 AMBASSADOR_DOCKER_IMAGE = $(shell sed -n 2p docker/$(LCNAME).docker.push.remote 2>/dev/null)
 export AMBASSADOR_DOCKER_IMAGE
 

--- a/build-aux/builder.mk
+++ b/build-aux/builder.mk
@@ -450,7 +450,7 @@ save-pytest-images: FORCE inspect-image-cache build-pytest-images
 	done
 .PHONY: save-pytest-images
 
-AMBASSADOR_DOCKER_IMAGE = $(shell sed -n 2p docker/$(LCNAME).docker.push.remote 2>/dev/null)
+AMBASSADOR_DOCKER_IMAGE = $(shell sed -n 2p docker/$(LCNAME).docker.tag.local 2>/dev/null)
 export AMBASSADOR_DOCKER_IMAGE
 
 _user-vars  = BUILDER_NAME

--- a/build-aux/builder.mk
+++ b/build-aux/builder.mk
@@ -197,7 +197,6 @@ export PYTEST_ARGS
 python-virtual-environment: $(OSS_HOME)/venv
 .PHONY: python-virtual-environment
 
-python-integration-test-environment: push-pytest-images
 python-integration-test-environment: $(tools/kubestatus)
 python-integration-test-environment: $(tools/kubectl)
 python-integration-test-environment: python-virtual-environment

--- a/build-aux/builder.mk
+++ b/build-aux/builder.mk
@@ -245,7 +245,7 @@ pytest-kat-envoy3-tests: # doing this all at once is too much for CI...
 	$(MAKE) pytest-run-tests PYTEST_ARGS="$$PYTEST_ARGS python/tests/kat"
 pytest-kat-envoy3: python-integration-test-environment pytest-kat-envoy3-tests
 # ... so we have a separate rule to run things split up
-build-aux/.pytest-kat.txt.stamp: $(OSS_HOME)/venv build-pytest-images $(tools/kubectl) FORCE
+build-aux/.pytest-kat.txt.stamp: $(OSS_HOME)/venv $(tools/kubectl) FORCE
 	. venv/bin/activate && set -o pipefail && pytest --collect-only python/tests/kat 2>&1 | sed -En 's/.*<Function (.*)>/\1/p' | cut -d. -f1 | sort -u > $@
 build-aux/pytest-kat.txt: build-aux/%: build-aux/.%.stamp $(tools/copy-ifchanged)
 	$(tools/copy-ifchanged) $< $@

--- a/build-aux/builder.mk
+++ b/build-aux/builder.mk
@@ -245,7 +245,7 @@ pytest-kat-envoy3-tests: # doing this all at once is too much for CI...
 	$(MAKE) pytest-run-tests PYTEST_ARGS="$$PYTEST_ARGS python/tests/kat"
 pytest-kat-envoy3: python-integration-test-environment pytest-kat-envoy3-tests
 # ... so we have a separate rule to run things split up
-build-aux/.pytest-kat.txt.stamp: $(OSS_HOME)/venv push-pytest-images $(tools/kubectl) FORCE
+build-aux/.pytest-kat.txt.stamp: $(OSS_HOME)/venv build-pytest-images $(tools/kubectl) FORCE
 	. venv/bin/activate && set -o pipefail && pytest --collect-only python/tests/kat 2>&1 | sed -En 's/.*<Function (.*)>/\1/p' | cut -d. -f1 | sort -u > $@
 build-aux/pytest-kat.txt: build-aux/%: build-aux/.%.stamp $(tools/copy-ifchanged)
 	$(tools/copy-ifchanged) $< $@

--- a/build-aux/check.mk
+++ b/build-aux/check.mk
@@ -3,6 +3,11 @@ include build-aux/tools.mk
 #
 # Auxiliary Docker images needed for the tests
 
+build-pytest-images: docker/test-auth.docker.tag.local
+build-pytest-images: docker/test-shadow.docker.tag.local
+build-pytest-images: docker/test-stats.docker.tag.local
+.PHONY: build-pytest-images
+
 # Keep this list in-sync with python/tests/integration/manifests.py
 push-pytest-images: docker/$(LCNAME).docker.push.remote
 push-pytest-images: docker/test-auth.docker.push.remote

--- a/docker/base-python.docker.gen
+++ b/docker/base-python.docker.gen
@@ -42,6 +42,8 @@ if tput setaf 0 &>/dev/null; then
 	BLU="$(tput setaf 4)"
 fi
 
+SKIP_PUSH=${SKIP_PUSH:-"false"}
+
 msg() {
 	# shellcheck disable=SC2059
 	printf "${BLU} => [${0##*/}]${OFF} $1${OFF}\n" "${@:2}" >&2
@@ -190,7 +192,11 @@ main() {
 		for repo in "${repos[@]}"; do
 			statnl_busy 'Attempting to push %q' "$repo:$tag"
 			docker tag "$id" "$repo:$tag" >&2
-			if docker push "$repo:$tag" >&2; then
+			if [[ "$SKIP_PUSH" == "true" ]]; then
+				statnl_done "${GRN}skipping push"
+				pushed=1
+				continue
+			elif docker push "$repo:$tag" >&2; then
 				statnl_done "${GRN}pushed"
 				pushed=1
 				continue

--- a/python/tests/integration/manifests.py
+++ b/python/tests/integration/manifests.py
@@ -24,7 +24,7 @@ def _get_images() -> Dict[str, str]:
 
     try:
         subprocess.run(
-            ["make"] + [f"docker/{name}.docker.push.remote" for name in image_names],
+            ["make"] + [f"docker/{name}.docker.tag.local" for name in image_names],
             check=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -34,7 +34,7 @@ def _get_images() -> Dict[str, str]:
         raise Exception(f"{err.stdout}{err}") from err
 
     for name in image_names:
-        with open(f"docker/{name}.docker.push.remote", "r") as fh:
+        with open(f"docker/{name}.docker.tag.local", "r") as fh:
             # file contents:
             #   line 1: image ID
             #   line 2: tag 1


### PR DESCRIPTION
## Description

This PR adds a Github action worfklow that calls `make save-dev` to export the emissary/kat-client/kat-server docker images as tarballs and upload them to the artifact store on GitHub. 
